### PR TITLE
fix: extract line-level statistics (additions/deletions) from GitHub API

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -30011,6 +30011,8 @@ async function run() {
             let addedFiles = [];
             let modifiedFiles = [];
             let removedFiles = [];
+            let additions;
+            let deletions;
             if (octokit) {
                 try {
                     core.info(`📡 Fetching file changes for commit ${commit.id.substring(0, 7)} via GitHub API`);
@@ -30022,7 +30024,11 @@ async function run() {
                     addedFiles = commitDetails.data.files?.filter(f => f.status === 'added').map(f => f.filename) || [];
                     modifiedFiles = commitDetails.data.files?.filter(f => f.status === 'modified').map(f => f.filename) || [];
                     removedFiles = commitDetails.data.files?.filter(f => f.status === 'removed').map(f => f.filename) || [];
+                    // Extract line-level statistics
+                    additions = commitDetails.data.stats?.additions;
+                    deletions = commitDetails.data.stats?.deletions;
                     core.info(`✅ Found ${addedFiles.length} added, ${modifiedFiles.length} modified, ${removedFiles.length} removed files`);
+                    core.info(`📊 Stats: +${additions ?? 0} -${deletions ?? 0} lines`);
                 }
                 catch (error) {
                     core.warning(`Failed to fetch commit details for ${commit.id}: ${error}`);
@@ -30046,6 +30052,8 @@ async function run() {
                 },
                 timestamp: commit.timestamp,
                 url: `https://github.com/${context.repo.owner}/${context.repo.repo}/commit/${commit.id}`,
+                additions,
+                deletions,
                 files: {
                     added: addedFiles,
                     modified: modifiedFiles,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Commit data now includes line-change statistics (additions and deletions); logs include a stats line.

* Chores
  * Increased retry attempts to 5.
  * Switched ingest endpoint to production.
  * Updated User-Agent to 1.0.1.
  * Removed job_minutes from the payload; focus remains on repo/owner and commits.

* Tests
  * Updated tests to reflect new payload shape, headers, endpoint, and retry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->